### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop, main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    env:
+      CC: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test
+        run: make ci


### PR DESCRIPTION
## Notes
- Could not finish running `make ci` locally because it runs a lengthy fuzzing test suite; the command was terminated after 1 minute.

## Summary
- add GitHub Actions workflow to run `make ci` with gcc and clang compilers
