### PR TITLE
Add benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,19 @@
+name: Benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run benchmark
+        run: make bench DISABLE_FUZZ=1
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-output
+          path: benchmark_out/benchmark.output
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a benchmark workflow that runs `make bench`
- upload results using `actions/upload-artifact@v4` and ignore missing output

## Testing
- `make ci DISABLE_FUZZ=1`
- `make bench DISABLE_FUZZ=1` *(fails: unable to download corpus)*
