### PR TITLE
Add benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,19 @@
+name: Benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run benchmark
+        run: make bench DISABLE_FUZZ=1
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-output
+          path: benchmark_out/benchmark.output
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ CORPUS_URL=	http://corpus.canterbury.ac.nz/resources/${CORPUS_ARCHIVE}
 BENCHMARK_OUT=	benchmark_out
 
 ## Uncomment one of these.
-DL=	curl -o ${CORPUS_ARCHIVE}
-#DL=	wget -O ${CORPUS_ARCHIVE}
+#DL=    curl -o ${CORPUS_ARCHIVE}
+DL=     wget -O ${CORPUS_ARCHIVE}
 
 bench: heatshrink corpus
 	mkdir -p ${BENCHMARK_OUT}


### PR DESCRIPTION
## Summary
- add a benchmark workflow that runs `make bench`
- use wget by default for retrieving the Canterbury corpus
- allow missing benchmark artifacts and update workflow to `actions/upload-artifact@v4`

## Testing
- `make ci DISABLE_FUZZ=1`
- `make bench DISABLE_FUZZ=1` *(fails: no route to host)*
