### PR TITLE
Add AVR cycle test and Avrora runner, integrate into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,12 @@ test_runners: test_heatshrink_static test_heatshrink_dynamic
 test: test_runners
 	./test_heatshrink_static
 	./test_heatshrink_dynamic
-	./scripts/run_avrora_cycle_test.sh
+	@if command -v avr-gcc >/dev/null 2>&1 && command -v java >/dev/null 2>&1 \
+		&& [ -n "$$AVRORA_JAR" ] && [ -f "$$AVRORA_JAR" ]; then \
+		./scripts/run_avrora_cycle_test.sh; \
+	else \
+		echo "WARNING: skipping Avrora cycle test (need avr-gcc, java, and AVRORA_JAR=<path-to-avrora.jar>)"; \
+	fi
 ci: test
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test_runners: test_heatshrink_static test_heatshrink_dynamic
 test: test_runners
 	./test_heatshrink_static
 	./test_heatshrink_dynamic
+	./scripts/run_avrora_cycle_test.sh
 ci: test
 
 clean:
@@ -123,4 +124,3 @@ libheatshrink_dynamic.a: ${DYNAMIC_OBJS}
 
 *.os: Makefile *.h
 *.od: Makefile *.h
-

--- a/avr_cycle_test.c
+++ b/avr_cycle_test.c
@@ -121,7 +121,7 @@ static uint8_t run_decompress_test(void) {
             if (poll_res == HSDR_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSDR_POLL_MORE || produced > INPUT_LEN) {
+            if (poll_res != HSDR_POLL_MORE || produced >= INPUT_LEN) {
                 return 8;
             }
         }
@@ -137,7 +137,7 @@ static uint8_t run_decompress_test(void) {
             if (poll_res == HSDR_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSDR_POLL_MORE || produced > INPUT_LEN) {
+            if (poll_res != HSDR_POLL_MORE || produced >= INPUT_LEN) {
                 return 9;
             }
         }

--- a/avr_cycle_test.c
+++ b/avr_cycle_test.c
@@ -1,0 +1,191 @@
+#include <avr/pgmspace.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "heatshrink_decoder.h"
+#include "heatshrink_encoder.h"
+
+#define ARRAY_LEN(x) (sizeof(x) / sizeof((x)[0]))
+#define INPUT_LEN 68u
+#define COMPRESSED_CAPACITY 128u
+
+#define AVR_LABEL(name) __asm__ __volatile__(".global " #name "\n" #name ":\n" ::: "memory")
+
+static const uint8_t sample_plaintext[INPUT_LEN] PROGMEM =
+    "This is AVR test data. This is AVR test data. This is AVR test data.";
+
+static const uint8_t sample_compressed[29] PROGMEM = {
+    0xaa, 0x5a, 0x2d, 0x37, 0x39, 0x00, 0x08, 0xa8,
+    0x35, 0x6a, 0x94, 0x82, 0xe9, 0x65, 0xb9, 0xdd,
+    0x24, 0x16, 0x4b, 0x0d, 0xd2, 0xc3, 0x2e, 0x90,
+    0x05, 0xbc, 0x2d, 0xe1, 0x6c,
+};
+
+volatile uint8_t test_status;
+
+static uint8_t run_compress_test(void) {
+    uint8_t plaintext[INPUT_LEN];
+    uint8_t compressed[COMPRESSED_CAPACITY];
+    size_t sunk = 0;
+    size_t produced = 0;
+    heatshrink_encoder hse;
+
+    memcpy_P(plaintext, sample_plaintext, INPUT_LEN);
+    heatshrink_encoder_reset(&hse);
+
+    while (sunk < INPUT_LEN) {
+        size_t input_size = 0;
+        HSE_sink_res sink_res = heatshrink_encoder_sink(
+            &hse, plaintext + sunk, INPUT_LEN - sunk, &input_size);
+        if (sink_res != HSER_SINK_OK || input_size == 0) {
+            return 1;
+        }
+        sunk += input_size;
+
+        while (1) {
+            size_t output_size = 0;
+            HSE_poll_res poll_res = heatshrink_encoder_poll(
+                &hse, compressed + produced, COMPRESSED_CAPACITY - produced,
+                &output_size);
+            produced += output_size;
+            if (poll_res == HSER_POLL_EMPTY) {
+                break;
+            }
+            if (poll_res != HSER_POLL_MORE || produced >= COMPRESSED_CAPACITY) {
+                return 2;
+            }
+        }
+    }
+
+    while (1) {
+        HSE_finish_res fin = heatshrink_encoder_finish(&hse);
+        while (1) {
+            size_t output_size = 0;
+            HSE_poll_res poll_res = heatshrink_encoder_poll(
+                &hse, compressed + produced, COMPRESSED_CAPACITY - produced,
+                &output_size);
+            produced += output_size;
+            if (poll_res == HSER_POLL_EMPTY) {
+                break;
+            }
+            if (poll_res != HSER_POLL_MORE || produced >= COMPRESSED_CAPACITY) {
+                return 3;
+            }
+        }
+        if (fin == HSER_FINISH_DONE) {
+            break;
+        }
+        if (fin != HSER_FINISH_MORE) {
+            return 4;
+        }
+    }
+
+    if (produced != ARRAY_LEN(sample_compressed)) {
+        return 5;
+    }
+    for (size_t i = 0; i < produced; i++) {
+        if (compressed[i] != pgm_read_byte(&sample_compressed[i])) {
+            return 6;
+        }
+    }
+
+    return 0;
+}
+
+static uint8_t run_decompress_test(void) {
+    uint8_t compressed[ARRAY_LEN(sample_compressed)];
+    uint8_t output[INPUT_LEN];
+    size_t sunk = 0;
+    size_t produced = 0;
+    heatshrink_decoder hsd;
+
+    memcpy_P(compressed, sample_compressed, ARRAY_LEN(sample_compressed));
+    heatshrink_decoder_reset(&hsd);
+
+    while (sunk < ARRAY_LEN(sample_compressed)) {
+        size_t input_size = 0;
+        HSD_sink_res sink_res = heatshrink_decoder_sink(
+            &hsd, compressed + sunk, ARRAY_LEN(sample_compressed) - sunk,
+            &input_size);
+        if ((sink_res != HSDR_SINK_OK && sink_res != HSDR_SINK_FULL) ||
+            input_size == 0) {
+            return 7;
+        }
+        sunk += input_size;
+
+        while (1) {
+            size_t output_size = 0;
+            HSD_poll_res poll_res = heatshrink_decoder_poll(
+                &hsd, output + produced, INPUT_LEN - produced, &output_size);
+            produced += output_size;
+            if (poll_res == HSDR_POLL_EMPTY) {
+                break;
+            }
+            if (poll_res != HSDR_POLL_MORE || produced > INPUT_LEN) {
+                return 8;
+            }
+        }
+    }
+
+    while (1) {
+        HSD_finish_res fin = heatshrink_decoder_finish(&hsd);
+        while (1) {
+            size_t output_size = 0;
+            HSD_poll_res poll_res = heatshrink_decoder_poll(
+                &hsd, output + produced, INPUT_LEN - produced, &output_size);
+            produced += output_size;
+            if (poll_res == HSDR_POLL_EMPTY) {
+                break;
+            }
+            if (poll_res != HSDR_POLL_MORE || produced > INPUT_LEN) {
+                return 9;
+            }
+        }
+        if (fin == HSDR_FINISH_DONE) {
+            break;
+        }
+        if (fin != HSDR_FINISH_MORE) {
+            return 10;
+        }
+    }
+
+    if (produced != INPUT_LEN) {
+        return 11;
+    }
+    for (size_t i = 0; i < INPUT_LEN; i++) {
+        if (output[i] != pgm_read_byte(&sample_plaintext[i])) {
+            return 12;
+        }
+    }
+
+    return 0;
+}
+
+int main(void) {
+    test_status = 0xff;
+
+    AVR_LABEL(compress_start);
+    uint8_t res = run_compress_test();
+    AVR_LABEL(compress_end);
+    if (res != 0) {
+        test_status = res;
+        goto test_fail;
+    }
+
+    AVR_LABEL(decompress_start);
+    res = run_decompress_test();
+    AVR_LABEL(decompress_end);
+
+    test_status = res;
+    if (res == 0) {
+        __asm__ __volatile__(".global test_ok\n"
+                             "test_ok:\n" ::: "memory");
+        __asm__ __volatile__("break");
+    }
+
+test_fail:
+    __asm__ __volatile__(".global test_fail\n"
+                         "test_fail:\n" ::: "memory");
+    __asm__ __volatile__("break");
+    return 0;
+}

--- a/scripts/run_avrora_cycle_test.sh
+++ b/scripts/run_avrora_cycle_test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AVRORA_JAR:=avrora.jar}"
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "FAIL: required tool '$1' not found" >&2
+        exit 1
+    fi
+}
+
+require_tool avr-gcc
+require_tool java
+
+if [[ ! -f "$AVRORA_JAR" ]]; then
+    echo "FAIL: AVRORA_JAR not found at '$AVRORA_JAR'" >&2
+    exit 1
+fi
+
+build_dir=".avrora-test"
+mkdir -p "$build_dir"
+elf="$build_dir/avr_cycle_test.elf"
+
+avr-gcc -mmcu=atmega328p -DF_CPU=16000000UL -std=c99 -Os -g -Wall -Wextra \
+    -DHEATSHRINK_DYNAMIC_ALLOC=0 \
+    -o "$elf" \
+    avr_cycle_test.c heatshrink_encoder.c heatshrink_decoder.c
+
+simulate_help=$(java -jar "$AVRORA_JAR" -help simulate 2>&1)
+trip_help=$(java -jar "$AVRORA_JAR" -help trip-time 2>&1)
+
+monitor_opt=$(printf '%s\n' "$simulate_help" | awk '
+    /-monitors[ =]/ {print "-monitors"; found=1; exit}
+    /-monitor[ =]/ {print "-monitor"; found=1; exit}
+    END {if (!found) exit 1}
+') || {
+    echo "FAIL: could not determine monitor option from -help simulate" >&2
+    exit 1
+}
+
+stop_opt=$(printf '%s\n' "$simulate_help" | awk '
+    /-cycles[ =]/ {print "-cycles"; found=1; exit}
+    /-seconds[ =]/ {print "-seconds"; found=1; exit}
+    END {if (!found) exit 1}
+') || {
+    echo "FAIL: could not determine stop option from -help simulate" >&2
+    exit 1
+}
+
+from_opt=$(printf '%s\n' "$trip_help" | awk '
+    /-from[ =]/ {print "-from"; found=1; exit}
+    /-start[ =]/ {print "-start"; found=1; exit}
+    END {if (!found) exit 1}
+') || {
+    echo "FAIL: could not determine trip-time start option from -help trip-time" >&2
+    exit 1
+}
+
+to_opt=$(printf '%s\n' "$trip_help" | awk '
+    /-to[ =]/ {print "-to"; found=1; exit}
+    /-end[ =]/ {print "-end"; found=1; exit}
+    END {if (!found) exit 1}
+') || {
+    echo "FAIL: could not determine trip-time end option from -help trip-time" >&2
+    exit 1
+}
+
+run_trip_time() {
+    local from_sym="$1"
+    local to_sym="$2"
+    local out
+    out=$(java -jar "$AVRORA_JAR" -action=simulate \
+        "${monitor_opt}=trip-time" \
+        "${from_opt}=${from_sym}" \
+        "${to_opt}=${to_sym}" \
+        "${stop_opt}=5" \
+        "$elf" 2>&1)
+    printf '%s\n' "$out"
+}
+
+extract_cycles() {
+    printf '%s\n' "$1" | awk '
+        match($0, /([0-9]+)[[:space:]]+cycles/, m) {print m[1]; exit}
+    '
+}
+
+compress_out=$(run_trip_time compress_start compress_end)
+decompress_out=$(run_trip_time decompress_start decompress_end)
+status_out=$(run_trip_time decompress_end test_ok)
+
+compress_cycles=$(extract_cycles "$compress_out")
+decompress_cycles=$(extract_cycles "$decompress_out")
+status_trip_cycles=$(extract_cycles "$status_out")
+
+if [[ -z "$compress_cycles" || -z "$decompress_cycles" || -z "$status_trip_cycles" ]]; then
+    echo "FAIL: could not parse Avrora trip-time output" >&2
+    exit 1
+fi
+
+if (( compress_cycles == 0 || decompress_cycles == 0 || status_trip_cycles == 0 )); then
+    echo "FAIL: invalid cycle result (zero) or functional status not OK" >&2
+    exit 1
+fi
+
+echo "compress_cycles=${compress_cycles}"
+echo "decompress_cycles=${decompress_cycles}"


### PR DESCRIPTION
### Motivation
- Add an AVR-targeted functional and cycle-count test to validate `heatshrink_encoder`/`heatshrink_decoder` on AVR devices and measure execution cycles using Avrora.
- Integrate the AVR cycle test into the existing test workflow so cycle measurements can be collected as part of CI or local `make test` runs.

### Description
- Add `avr_cycle_test.c` which runs an encoder and decoder round-trip using PROGMEM sample data and exposes labeled symbols for measuring trip-time in Avrora. 
- Add `scripts/run_avrora_cycle_test.sh` which builds an ELF with `avr-gcc`, invokes Avrora to measure trip-time between labeled symbols, parses cycle counts, and validates tools and outputs.
- Update `Makefile` so the `test` target invokes `./scripts/run_avrora_cycle_test.sh`, and ensure build artifacts for AVR testing are produced in a temporary `.avrora-test` directory.
- The Avrora runner autodetects the appropriate `-monitor`/`-monitors` and `-cycles`/`-seconds` and `-from`/`-start`/`-to`/`-end` options from Avrora `-help` output to support multiple Avrora versions.

### Testing
- No automated tests were executed as part of this rollout; the new script contains runtime checks that exit non-zero on failure and prints `compress_cycles` and `decompress_cycles` on success.
- The `make test` target is updated to call `./scripts/run_avrora_cycle_test.sh` so running `make test` on a host with `avr-gcc`, `java`, and a valid Avrora JAR will run the AVR cycle tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5323b1498833198115e424fb947e0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added AVR microcontroller-based performance tests for compression and decompression.
  * Added an automated cycle-counting harness that measures and reports execution cycles for compression and decompression runs.

* **Chores**
  * Build system updated to run the new cycle-counting tests automatically when required tools are available; otherwise it skips with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->