### PR TITLE
Handle transition to search with input_size of 0 on finish

### DIFF
--- a/avr_cycle_test.c
+++ b/avr_cycle_test.c
@@ -77,6 +77,26 @@ static uint8_t run_compress_test(void) {
     size_t produced = 0;
     heatshrink_encoder *hse = &hs_state.enc;
 
+    /* Regression check: finishing with no queued input must transition
+     * directly to bit flushing, otherwise 16-bit targets can get stuck
+     * in SEARCH due to unsigned underflow in the end-of-search check. */
+    heatshrink_encoder_reset(hse);
+    if (heatshrink_encoder_finish(hse) != HSER_FINISH_MORE) {
+        return 13;
+    }
+    size_t empty_output_size = 0;
+    HSE_poll_res empty_poll_res =
+        heatshrink_encoder_poll(hse,
+                                output_chunk,
+                                sizeof(output_chunk),
+                                &empty_output_size);
+    if (empty_poll_res != HSER_POLL_EMPTY || empty_output_size != 0) {
+        return 14;
+    }
+    if (heatshrink_encoder_finish(hse) != HSER_FINISH_DONE) {
+        return 15;
+    }
+
     memcpy_P(plaintext, sample_plaintext, INPUT_LEN);
     heatshrink_encoder_reset(hse);
 

--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -265,7 +265,9 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
         msi, hse->input_size + msi, 2*window_length, hse->input_size);
 
     bool fin = is_finishing(hse);
-    if (msi > hse->input_size - (fin ? 1 : lookahead_sz)) {
+    if (fin && hse->input_size == 0) {
+        return HSES_FLUSH_BITS;
+    } else if (msi > hse->input_size - (fin ? 1 : lookahead_sz)) {
         /* Current search buffer is exhausted, copy it into the
          * backlog and await more input. */
         LOG("-- end of search @ %d\n", msi);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encoder finalization so compression correctly completes when no input remains, avoiding incorrect leftover state during the final stage.

* **Tests**
  * Added a precondition regression check to ensure encoder finish behavior is verified before running compression validation, preventing misleading test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->