### PR TITLE
Harden ABI probe and mark CI targets .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ ci: host-abi test
 cross: cross-avr cross-msp430
 cross-avr: abi_probe_avr.o heatshrink_encoder_avr.o heatshrink_decoder_avr.o
 cross-msp430: abi_probe_msp430.o heatshrink_encoder_msp430.o heatshrink_decoder_msp430.o
+.PHONY: host-abi ci cross cross-avr cross-msp430
 
 clean:
 	rm -f heatshrink test_heatshrink_{dynamic,static} \

--- a/abi_probe.c
+++ b/abi_probe.c
@@ -9,7 +9,9 @@
  *
  */
 
+#ifndef ABI_BITS
 #define ABI_BITS(T) ((int)(sizeof(T) * CHAR_BIT))
+#endif
 
 /* General assumptions that should hold on all supported targets. */
 _Static_assert(CHAR_BIT == 8, "heatshrink requires 8-bit bytes");
@@ -94,6 +96,20 @@ _Static_assert(FLT_RADIX == 2, "non-binary floating point not expected");
 #define ABI_EXPECT_UINT_FAST8_BITS   8
 #define ABI_EXPECT_UINT_FAST16_BITS  64
 #define ABI_EXPECT_UINT_FAST32_BITS  64
+#endif
+
+#if !defined(ABI_EXPECT_SHORT_BITS) || \
+    !defined(ABI_EXPECT_INT_BITS) || \
+    !defined(ABI_EXPECT_LONG_BITS) || \
+    !defined(ABI_EXPECT_LLONG_BITS) || \
+    !defined(ABI_EXPECT_PTR_BITS) || \
+    !defined(ABI_EXPECT_SIZE_T_BITS) || \
+    !defined(ABI_EXPECT_UINT_FAST8_BITS) || \
+    !defined(ABI_EXPECT_UINT_FAST16_BITS) || \
+    !defined(ABI_EXPECT_UINT_FAST32_BITS) || \
+    !defined(ABI_EXPECT_FLOAT_BITS) || \
+    !defined(ABI_EXPECT_DOUBLE_BITS)
+#error "unsupported target: ABI expectations not defined for this platform"
 #endif
 
 _Static_assert(ABI_BITS(short) == ABI_EXPECT_SHORT_BITS, "unexpected short width for target profile");


### PR DESCRIPTION
### Motivation
- Prevent hard-to-debug build errors when target-specific `ABI_EXPECT_*` macros are missing by producing a clear compile-time diagnostic. 
- Ensure Makefile non-file targets always run by marking `host-abi`, `ci`, `cross`, `cross-avr`, and `cross-msp430` as phony.

### Description
- In `abi_probe.c` add a `#ifndef ABI_BITS` guard and define `ABI_BITS(T)` if not already provided. 
- Add a preprocessor check that `#error`s when any of the target expectation macros are not defined, covering `ABI_EXPECT_SHORT_BITS`, `ABI_EXPECT_INT_BITS`, `ABI_EXPECT_LONG_BITS`, `ABI_EXPECT_LLONG_BITS`, `ABI_EXPECT_PTR_BITS`, `ABI_EXPECT_SIZE_T_BITS`, `ABI_EXPECT_UINT_FAST8_BITS`, `ABI_EXPECT_UINT_FAST16_BITS`, `ABI_EXPECT_UINT_FAST32_BITS`, `ABI_EXPECT_FLOAT_BITS`, and `ABI_EXPECT_DOUBLE_BITS`.
- In `Makefile` add `.PHONY: host-abi ci cross cross-avr cross-msp430` so those compile-only CI targets run even if files with those names exist.

### Testing
- Ran `make host-abi`, which compiled `abi_probe.c` successfully (exit 0).
- The build produced a preexisting compiler warning about `abi_probe` having no previous prototype, which did not block the compile and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de39eef4ac83319a1863f228d7b0bb)