### PR TITLE
Run AVR/MSP430 cross-compilation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ jobs:
       - name: Build and test
         run: make ci DISABLE_FUZZ=1
 
+  build-embedded-cross:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install AVR and MSP430 toolchains
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-avr binutils-avr avr-libc msp430-elf-gcc
+      - name: Cross-compile AVR and MSP430 objects
+        run: |
+          make clean
+          make cross
+
   build-32:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
### Motivation
- Ensure AVR and MSP430 cross-compilation targets are built on CI so target-width / ABI issues are caught early.
- Make cross-compile checks part of every CI run (push, PR, workflow dispatch) without running the embedded tests on hardware.

### Description
- Add a new `build-embedded-cross` job to `.github/workflows/ci.yml` that runs on `ubuntu-latest`.
- Install AVR and MSP430 cross toolchains via `apt` (`gcc-avr`, `binutils-avr`, `avr-libc`, `msp430-elf-gcc`) in that job.
- Run `make clean` followed by `make cross` to compile the AVR/MSP430 compile-only object targets (`cross-avr` and `cross-msp430`).

### Testing
- Ran `make ci DISABLE_FUZZ=1` locally and the host build and test suites completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de3aaf883c8331ba6202a1e6e9e85d)