### PR TITLE
Fix simavr VCD timestamp handling and silence ShellCheck unused variable

### DIFF
--- a/scripts/run_simavr_cycle_test.sh
+++ b/scripts/run_simavr_cycle_test.sh
@@ -115,15 +115,78 @@ extract_phase_timestamps() {
     ' "$vcd"
 }
 
+extract_vcd_timescale_ns() {
+    awk '
+        function unit_scale(unit) {
+            if (unit == "s") return 1000000000;
+            if (unit == "ms") return 1000000;
+            if (unit == "us") return 1000;
+            if (unit == "ns") return 1;
+            return 0;
+        }
+
+        /^\$timescale$/ {
+            mode = 1;
+            next;
+        }
+
+        mode && /^\$end$/ {
+            mode = 0;
+            if (value > 0 && scale > 0) {
+                print value * scale;
+                exit 0;
+            }
+            exit 1;
+        }
+
+        mode && value == 0 {
+            token = $1;
+            if (token ~ /^[0-9]+$/) {
+                value = token + 0;
+                if (NF >= 2) {
+                    scale = unit_scale($2);
+                }
+                next;
+            }
+            if (token ~ /^[0-9]+[a-z]+$/) {
+                unit = token;
+                gsub(/^[0-9]+/, "", unit);
+                value = token + 0;
+                scale = unit_scale(unit);
+                next;
+            }
+        }
+
+        mode && value > 0 && scale == 0 {
+            scale = unit_scale($1);
+        }
+
+        END {
+            if (value > 0 && scale > 0) {
+                print value * scale;
+                exit 0;
+            }
+            exit 1;
+        }
+    ' "$vcd"
+}
+
 timestamps=$(extract_phase_timestamps) || {
     cat "$log" >&2 || true
     fail "did not observe a complete phase_marker trace in '$vcd'"
 }
 
-read -r t1 t2 t3 t4 t5 <<< "$timestamps"
+vcd_tick_ns=$(extract_vcd_timescale_ns) || {
+    fail "could not parse VCD \$timescale from '$vcd'"
+}
 
-compress_ns=$((t2 - t1))
-decompress_ns=$((t4 - t3))
+read -r t1 t2 t3 t4 _ <<< "$timestamps"
+
+compress_ticks=$((t2 - t1))
+decompress_ticks=$((t4 - t3))
+
+compress_ns=$((compress_ticks * vcd_tick_ns))
+decompress_ns=$((decompress_ticks * vcd_tick_ns))
 
 if (( compress_ns <= 0 || decompress_ns <= 0 )); then
     fail "non-positive timing interval in VCD trace"


### PR DESCRIPTION
### Motivation
- The simavr VCD trace uses a configurable tick size (e.g. `$timescale 10ns`), but the script treated raw VCD timestamps as nanoseconds which caused ~10x errors when computing cycle counts and alignment checks. 
- The `read` assignment earlier exposed an unused variable warning for the fifth timestamp field which should be ignored to satisfy ShellCheck.

### Description
- Added `extract_vcd_timescale_ns()` which parses the VCD `$timescale` directive and returns the tick size in nanoseconds, supporting units `s`, `ms`, `us`, and `ns` using `awk`.
- Converted the extracted phase timestamp deltas from VCD ticks to nanoseconds by multiplying deltas by `vcd_tick_ns` before performing divisibility and cycle-count math against `ns_per_cycle`.
- Replaced the unused `t5` binding with a throwaway `_` in the `read` invocation (`read -r t1 t2 t3 t4 _ <<< "$timestamps"`) to silence unused-variable warnings while preserving behavior.
- Kept the remainder of the cycle calculation logic intact and wrote `compress_cycles`/`decompress_cycles` to the metrics file as before; changes are in `scripts/run_simavr_cycle_test.sh`.

### Testing
- Ran `bash -n scripts/run_simavr_cycle_test.sh` to validate script syntax and it succeeded. 
- Attempted `make clean && ./scripts/run_simavr_cycle_test.sh`, but the run aborted with `FAIL: required tool 'avr-gcc' not found` in this environment, demonstrating the script correctly detects missing toolchains (environment limitation, not a functional failure of the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e36b1cb384833183cda97f8653f8fb)