### PR TITLE
Stream heatshrink poll through small chunk buffer and detect test_status from VCD in runner

### DIFF
--- a/avr_cycle_test.c
+++ b/avr_cycle_test.c
@@ -72,7 +72,7 @@ static void stop_simulation(void) {
 
 static uint8_t run_compress_test(void) {
     uint8_t plaintext[INPUT_LEN];
-    uint8_t compressed[COMPRESSED_CAPACITY];
+    uint8_t output_chunk[16];
     size_t sunk = 0;
     size_t produced = 0;
     heatshrink_encoder *hse = &hs_state.enc;
@@ -93,14 +93,22 @@ static uint8_t run_compress_test(void) {
             size_t output_size = 0;
             HSE_poll_res poll_res =
                 heatshrink_encoder_poll(hse,
-                                        compressed + produced,
-                                        COMPRESSED_CAPACITY - produced,
+                                        output_chunk,
+                                        sizeof(output_chunk),
                                         &output_size);
-            produced += output_size;
+            for (size_t i = 0; i < output_size; i++) {
+                if (produced >= ARRAY_LEN(sample_compressed)) {
+                    return 5;
+                }
+                if (output_chunk[i] != pgm_read_byte(&sample_compressed[produced])) {
+                    return 6;
+                }
+                produced++;
+            }
             if (poll_res == HSER_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSER_POLL_MORE || produced >= COMPRESSED_CAPACITY) {
+            if (poll_res != HSER_POLL_MORE) {
                 return 2;
             }
         }
@@ -112,14 +120,22 @@ static uint8_t run_compress_test(void) {
             size_t output_size = 0;
             HSE_poll_res poll_res =
                 heatshrink_encoder_poll(hse,
-                                        compressed + produced,
-                                        COMPRESSED_CAPACITY - produced,
+                                        output_chunk,
+                                        sizeof(output_chunk),
                                         &output_size);
-            produced += output_size;
+            for (size_t i = 0; i < output_size; i++) {
+                if (produced >= ARRAY_LEN(sample_compressed)) {
+                    return 5;
+                }
+                if (output_chunk[i] != pgm_read_byte(&sample_compressed[produced])) {
+                    return 6;
+                }
+                produced++;
+            }
             if (poll_res == HSER_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSER_POLL_MORE || produced >= COMPRESSED_CAPACITY) {
+            if (poll_res != HSER_POLL_MORE) {
                 return 3;
             }
         }
@@ -131,12 +147,15 @@ static uint8_t run_compress_test(void) {
         }
     }
 
+    if (produced != ARRAY_LEN(sample_compressed)) {
+        return 5;
+    }
     return 0;
 }
 
 static uint8_t run_decompress_test(void) {
     uint8_t compressed[ARRAY_LEN(sample_compressed)];
-    uint8_t output[INPUT_LEN];
+    uint8_t output_chunk[16];
     size_t sunk = 0;
     size_t produced = 0;
     heatshrink_decoder *hsd = &hs_state.dec;
@@ -160,14 +179,22 @@ static uint8_t run_decompress_test(void) {
             size_t output_size = 0;
             HSD_poll_res poll_res =
                 heatshrink_decoder_poll(hsd,
-                                        output + produced,
-                                        INPUT_LEN - produced,
+                                        output_chunk,
+                                        sizeof(output_chunk),
                                         &output_size);
-            produced += output_size;
+            for (size_t i = 0; i < output_size; i++) {
+                if (produced >= INPUT_LEN) {
+                    return 11;
+                }
+                if (output_chunk[i] != pgm_read_byte(&sample_plaintext[produced])) {
+                    return 12;
+                }
+                produced++;
+            }
             if (poll_res == HSDR_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSDR_POLL_MORE || produced >= INPUT_LEN) {
+            if (poll_res != HSDR_POLL_MORE) {
                 return 8;
             }
         }
@@ -179,14 +206,22 @@ static uint8_t run_decompress_test(void) {
             size_t output_size = 0;
             HSD_poll_res poll_res =
                 heatshrink_decoder_poll(hsd,
-                                        output + produced,
-                                        INPUT_LEN - produced,
+                                        output_chunk,
+                                        sizeof(output_chunk),
                                         &output_size);
-            produced += output_size;
+            for (size_t i = 0; i < output_size; i++) {
+                if (produced >= INPUT_LEN) {
+                    return 11;
+                }
+                if (output_chunk[i] != pgm_read_byte(&sample_plaintext[produced])) {
+                    return 12;
+                }
+                produced++;
+            }
             if (poll_res == HSDR_POLL_EMPTY) {
                 break;
             }
-            if (poll_res != HSDR_POLL_MORE || produced >= INPUT_LEN) {
+            if (poll_res != HSDR_POLL_MORE) {
                 return 9;
             }
         }
@@ -201,12 +236,6 @@ static uint8_t run_decompress_test(void) {
     if (produced != INPUT_LEN) {
         return 11;
     }
-    for (size_t i = 0; i < INPUT_LEN; i++) {
-        if (output[i] != pgm_read_byte(&sample_plaintext[i])) {
-            return 12;
-        }
-    }
-
     return 0;
 }
 

--- a/scripts/run_simavr_cycle_test.sh
+++ b/scripts/run_simavr_cycle_test.sh
@@ -115,6 +115,51 @@ extract_phase_timestamps() {
     ' "$vcd"
 }
 
+extract_final_test_status() {
+    awk '
+        function bin2dec(bits,    i, v) {
+            v = 0;
+            for (i = 1; i <= length(bits); i++) {
+                v = (v * 2) + substr(bits, i, 1);
+            }
+            return v;
+        }
+
+        BEGIN {
+            sym = "";
+            last = "";
+            seen = 0;
+        }
+
+        $1 == "$var" && $(NF-1) == "test_status" {
+            sym = $4;
+            next;
+        }
+
+        sym != "" && $1 ~ /^b[01]+$/ && $2 == sym {
+            last = bin2dec(substr($1, 2));
+            seen = 1;
+            next;
+        }
+
+        sym != "" && $1 ~ /^[01][!-~]+$/ {
+            val = substr($1, 1, 1);
+            code = substr($1, 2);
+            if (code == sym) {
+                last = val + 0;
+                seen = 1;
+            }
+        }
+
+        END {
+            if (!seen) {
+                exit 1;
+            }
+            print last;
+        }
+    ' "$vcd"
+}
+
 extract_vcd_timescale_ns() {
     awk '
         function unit_scale(unit) {
@@ -204,6 +249,16 @@ timestamps=$(extract_phase_timestamps) || {
     cat "$log" >&2 || true
     fail "did not observe a complete phase_marker trace in '$vcd'"
 }
+
+test_status=$(extract_final_test_status) || {
+    cat "$log" >&2 || true
+    fail "did not observe a usable test_status trace in '$vcd'"
+}
+
+if (( test_status != 0 )); then
+    cat "$log" >&2 || true
+    fail "AVR functional test failed (test_status=$test_status)"
+fi
 
 vcd_tick_ns=$(extract_vcd_timescale_ns) || {
     fail "could not parse VCD \$timescale from '$vcd'"


### PR DESCRIPTION
### Motivation

- Reduce peak RAM usage on AVR by avoiding large contiguous output buffers when polling the heatshrink encoder/decoder. 
- Make the simavr test runner reliably detect the functional test result from the VCD `test_status` trace so CI can fail fast on device-level failures.

### Description

- In `avr_cycle_test.c` replace the large `compressed[]` and `output[]` arrays with a small `output_chunk[16]` buffer and handle `heatshrink_*_poll` output in a loop that verifies each byte against the expected `sample_compressed`/`sample_plaintext` via `pgm_read_byte` as it is produced. 
- Add bounds checks and explicit error return codes when produced output would overflow the expected sample length, and verify total produced length matches the expected size at the end of the compress/decompress flows. 
- Remove the previous final full-buffer comparison loops since verification is now done incrementally during polling. 
- In `scripts/run_simavr_cycle_test.sh` add `extract_final_test_status()` (an `awk` helper) to parse the final `test_status` value from the VCD and fail the script if the status is non-zero or not found, printing the simulator log on failure.

### Testing

- Ran the functional cycle test via `scripts/run_simavr_cycle_test.sh` (simavr/VCD-based test); the runner parsed timestamps and `test_status` and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5cb05547483318683a6c7470ff652)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored compression and decompression test validation to perform incremental byte-by-byte verification during polling, enabling earlier detection of output mismatches.
  * Added stricter error handling with enhanced early termination when output lengths exceed expected values.
  * Implemented automated test status extraction and validation from simulation output for more robust failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->