### PR TITLE
Add AVR regression coverage for empty-input encoder finish

### DIFF
--- a/avr_cycle_test.c
+++ b/avr_cycle_test.c
@@ -77,6 +77,26 @@ static uint8_t run_compress_test(void) {
     size_t produced = 0;
     heatshrink_encoder *hse = &hs_state.enc;
 
+    /* Regression check: finishing with no queued input must transition
+     * directly to bit flushing, otherwise 16-bit targets can get stuck
+     * in SEARCH due to unsigned underflow in the end-of-search check. */
+    heatshrink_encoder_reset(hse);
+    if (heatshrink_encoder_finish(hse) != HSER_FINISH_MORE) {
+        return 13;
+    }
+    size_t empty_output_size = 0;
+    HSE_poll_res empty_poll_res =
+        heatshrink_encoder_poll(hse,
+                                output_chunk,
+                                sizeof(output_chunk),
+                                &empty_output_size);
+    if (empty_poll_res != HSER_POLL_EMPTY || empty_output_size != 0) {
+        return 14;
+    }
+    if (heatshrink_encoder_finish(hse) != HSER_FINISH_DONE) {
+        return 15;
+    }
+
     memcpy_P(plaintext, sample_plaintext, INPUT_LEN);
     heatshrink_encoder_reset(hse);
 


### PR DESCRIPTION
### Motivation
- Add a targeted AVR functional regression that reproduces the empty-input finish path which previously caused 16-bit targets to get stuck in `SEARCH` due to unsigned underflow fixed by commit `31a58d777970bb505c9ff27d4b9cfcc98cbf8997`.

### Description
- Add a regression check at the start of `run_compress_test` in `avr_cycle_test.c` that resets the encoder, calls `heatshrink_encoder_finish`, polls and verifies `HSER_POLL_EMPTY` with zero bytes, and then verifies a final `HSER_FINISH_DONE` result, returning distinct error codes (`13`–`15`) on failure.
- Document in-code that this specifically protects 16-bit ABI targets (AVR) from the SEARCH-state underflow condition.
- Only `avr_cycle_test.c` was modified.

### Testing
- Ran `make test`, which completed with all host unit and integration tests passing.
- Ran `make avr-cycle`, which built and executed the AVR functional cycle test and completed successfully (AVR cycle run produced metrics).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e5d78433508331a9ad71935214b1a3)