### PR TITLE
Add nightly libtheft and fuzzing GitHub Actions workflows

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,25 @@
+name: Fuzzing
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub Actions cron uses UTC; this runs nightly in US time zones.
+    - cron: "17 09 * * *"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    env:
+      CC: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and test with fuzzing enabled
+        run: |
+          make clean
+          make ci

--- a/.github/workflows/libtheft.yml
+++ b/.github/workflows/libtheft.yml
@@ -1,0 +1,38 @@
+name: Libtheft
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub Actions cron uses UTC; this runs nightly in US time zones.
+    - cron: "17 08 * * *"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  libtheft:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    env:
+      CC: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out libtheft
+        uses: actions/checkout@v4
+        with:
+          repository: silentbicycle/theft
+          path: .deps/theft
+
+      - name: Build libtheft
+        run: make -C .deps/theft
+
+      - name: Build and test with libtheft
+        run: |
+          make clean
+          make ci DISABLE_FUZZ=1 \
+            THEFT_INC="-I$PWD/.deps/theft/inc" \
+            EXTRA_CFLAGS="-DHEATSHRINK_HAS_THEFT" \
+            EXTRA_LDFLAGS="$PWD/.deps/theft/build/libtheft.a -lm"


### PR DESCRIPTION
### Motivation

- Provide nightly and on-demand CI runs that exercise the libtheft property tests and the project's fuzzing code paths so regressions in those areas are caught regularly.

### Description

- Add `.github/workflows/libtheft.yml` which is triggered by `workflow_dispatch` and a nightly `cron`, runs on `ubuntu-latest` with a `gcc/clang` matrix, checks out `silentbicycle/theft` into `.deps/theft`, builds it, and runs `make ci` with `HEATSHRINK_HAS_THEFT` enabled via `THEFT_INC`, `EXTRA_CFLAGS`, and `EXTRA_LDFLAGS` while passing `DISABLE_FUZZ=1` for that job.
- Add `.github/workflows/fuzzing.yml` which is triggered by `workflow_dispatch` and a nightly `cron`, runs on `ubuntu-latest` with a `gcc/clang` matrix, and runs `make ci` without `DISABLE_FUZZ=1` so fuzzing is exercised.
- Both workflows use a small matrix (`compiler: [gcc, clang]`) and explicit UTC cron entries to run nightly.

### Testing

- Ran `make clean && make ci DISABLE_FUZZ=1` locally which completed successfully.
- Ran `make clean && make ci` locally with fuzzing enabled which completed successfully.
- Ran a Python check that ensured both workflow files contain `workflow_dispatch` and `schedule`, and that `fuzzing.yml` does not include `DISABLE_FUZZ=1`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04910899f08331b8e51fcc294193e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated fuzzing and library-based fuzz testing workflows to enhance code quality and security testing, with nightly and on-demand execution across multiple compiler configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miracoli/heatshrink/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->