### PR TITLE
Update theft property tests for current libtheft API

### DIFF
--- a/test_heatshrink_dynamic_theft.c
+++ b/test_heatshrink_dynamic_theft.c
@@ -307,6 +307,7 @@ prop_should_not_get_stuck(struct theft *t, void *input, void *window, void *look
     uint8_t lookahead_sz2 = *(uint8_t *)lookahead;
     if (lookahead_sz2 >= window_sz2) { return THEFT_TRIAL_SKIP; }
 
+    enum theft_trial_res res = THEFT_TRIAL_ERROR;
     heatshrink_decoder *hsd = heatshrink_decoder_alloc((64 * 1024L) - 1,
         window_sz2, lookahead_sz2);
     if (hsd == NULL) { return THEFT_TRIAL_ERROR; }
@@ -315,17 +316,21 @@ prop_should_not_get_stuck(struct theft *t, void *input, void *window, void *look
 
     size_t count = 0;
     HSD_sink_res sres = heatshrink_decoder_sink(hsd, r->buf, r->size, &count);
-    if (sres != HSDR_SINK_OK) { return THEFT_TRIAL_ERROR; }
+    if (sres != HSDR_SINK_OK) { goto cleanup; }
     
     size_t out_sz = 0;
     HSD_poll_res pres = heatshrink_decoder_poll(hsd, output, BUF_SIZE, &out_sz);
-    if (pres != HSDR_POLL_EMPTY) { return THEFT_TRIAL_FAIL; }
+    if (pres != HSDR_POLL_EMPTY) {
+        res = THEFT_TRIAL_FAIL;
+        goto cleanup;
+    }
     
     HSD_finish_res fres = heatshrink_decoder_finish(hsd);
-    heatshrink_decoder_free(hsd);
-    if (fres != HSDR_FINISH_DONE) { return THEFT_TRIAL_FAIL; }
+    res = (fres == HSDR_FINISH_DONE) ? THEFT_TRIAL_PASS : THEFT_TRIAL_FAIL;
 
-    return THEFT_TRIAL_PASS;
+cleanup:
+    heatshrink_decoder_free(hsd);
+    return res;
 }
 
 static bool get_time_seed(theft_seed *seed)
@@ -453,39 +458,46 @@ prop_encoded_and_decoded_data_should_match(struct theft *t, void *input,
     uint8_t lookahead_sz2 = *(uint8_t *)lookahead;
     if (lookahead_sz2 >= window_sz2) { return THEFT_TRIAL_SKIP; }
 
+    enum theft_trial_res res = THEFT_TRIAL_ERROR;
     heatshrink_encoder *hse = heatshrink_encoder_alloc(window_sz2, lookahead_sz2);
     if (hse == NULL) { return THEFT_TRIAL_ERROR; }
 
     assert(decoder_buffer_size);
     uint16_t buf_size = *(uint16_t *)decoder_buffer_size;
     heatshrink_decoder *hsd = heatshrink_decoder_alloc(buf_size, window_sz2, lookahead_sz2);
-    if (hsd == NULL) { return THEFT_TRIAL_ERROR; }
+    if (hsd == NULL) { goto cleanup_encoder; }
     
     rbuf *r = (rbuf *)input;
 
     size_t compressed_size = 0;
     if (!do_compress(hse, r->buf, r->size, output,
             BUF_SIZE, &compressed_size)) {
-        return THEFT_TRIAL_ERROR;
+        goto cleanup;
     }
 
     size_t decompressed_size = 0;
     if (!do_decompress(hsd, output, compressed_size, output2,
             BUF_SIZE, &decompressed_size)) {
-        return THEFT_TRIAL_ERROR;
+        goto cleanup;
     }
 
     // verify decompressed output matches original input
     if (r->size != decompressed_size) {
-        return THEFT_TRIAL_FAIL;
+        res = THEFT_TRIAL_FAIL;
+        goto cleanup;
     }
     if (0 != memcmp(output2, r->buf, decompressed_size)) {
-        return THEFT_TRIAL_FAIL;
+        res = THEFT_TRIAL_FAIL;
+        goto cleanup;
     }
     
-    heatshrink_encoder_free(hse);
+    res = THEFT_TRIAL_PASS;
+
+cleanup:
     heatshrink_decoder_free(hsd);
-    return THEFT_TRIAL_PASS;
+cleanup_encoder:
+    heatshrink_encoder_free(hse);
+    return res;
 }
 
 TEST encoded_and_decoded_data_should_match(void) {
@@ -528,6 +540,7 @@ prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(stru
     uint8_t lookahead_sz2 = *(uint8_t *)lookahead;
     if (lookahead_sz2 >= window_sz2) { return THEFT_TRIAL_SKIP; }
 
+    enum theft_trial_res res = THEFT_TRIAL_ERROR;
     heatshrink_encoder *hse = heatshrink_encoder_alloc(window_sz2, lookahead_sz2);
     if (hse == NULL) { return THEFT_TRIAL_ERROR; }
     
@@ -536,16 +549,15 @@ prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(stru
     size_t compressed_size = 0;
     if (!do_compress(hse, r->buf, r->size, output,
             BUF_SIZE, &compressed_size)) {
-        return THEFT_TRIAL_ERROR;
+        goto cleanup;
     }
 
     size_t ceil_9_8s = ceil_nine_eighths(r->size);
-    if (compressed_size > ceil_9_8s) {
-        return THEFT_TRIAL_FAIL;
-    }
+    res = (compressed_size > ceil_9_8s) ? THEFT_TRIAL_FAIL : THEFT_TRIAL_PASS;
 
+cleanup:
     heatshrink_encoder_free(hse);
-    return THEFT_TRIAL_PASS;
+    return res;
 }
 
 TEST encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(void) {
@@ -583,6 +595,7 @@ prop_encoder_should_always_make_progress(struct theft *t, void *instance, void *
     uint8_t lookahead_sz2 = *(uint8_t *)lookahead;
     if (lookahead_sz2 >= window_sz2) { return THEFT_TRIAL_SKIP; }
 
+    enum theft_trial_res res = THEFT_TRIAL_ERROR;
     heatshrink_encoder *hse = heatshrink_encoder_alloc(window_sz2, lookahead_sz2);
     if (hse == NULL) { return THEFT_TRIAL_ERROR; }
     
@@ -596,34 +609,38 @@ prop_encoder_should_always_make_progress(struct theft *t, void *instance, void *
             size_t input_size = 0;
             HSE_sink_res esres = heatshrink_encoder_sink(hse,
                 &r->buf[sunk], r->size - sunk, &input_size);
-            if (esres != HSER_SINK_OK) { return THEFT_TRIAL_ERROR; }
+            if (esres != HSER_SINK_OK) { goto cleanup; }
             sunk += input_size;
         } else {
             HSE_finish_res efres = heatshrink_encoder_finish(hse);
             if (efres == HSER_FINISH_DONE) {
+                res = THEFT_TRIAL_PASS;
                 break;
             } else if (efres != HSER_FINISH_MORE) {
                 printf("FAIL %d\n", __LINE__);
-                return THEFT_TRIAL_FAIL;
+                res = THEFT_TRIAL_FAIL;
+                goto cleanup;
             }
         }
 
         size_t output_size = 0;
         HSE_poll_res epres = heatshrink_encoder_poll(hse,
             output, BUF_SIZE, &output_size);
-        if (epres < 0) { return THEFT_TRIAL_ERROR; }
+        if (epres < 0) { goto cleanup; }
         if (output_size == 0 && sunk == r->size) {
             no_progress++;
             if (no_progress > 2) {
-                return THEFT_TRIAL_FAIL;
+                res = THEFT_TRIAL_FAIL;
+                goto cleanup;
             }
         } else {
             no_progress = 0;
         }
     }
 
+cleanup:
     heatshrink_encoder_free(hse);
-    return THEFT_TRIAL_PASS;
+    return res;
 }
 
 TEST encoder_should_always_make_progress(void) {
@@ -661,6 +678,7 @@ prop_decoder_should_always_make_progress(struct theft *t, void *instance, void *
     uint8_t lookahead_sz2 = *(uint8_t *)lookahead;
     if (lookahead_sz2 >= window_sz2) { return THEFT_TRIAL_SKIP; }
 
+    enum theft_trial_res res = THEFT_TRIAL_ERROR;
     heatshrink_decoder *hsd = heatshrink_decoder_alloc(512, window_sz2, lookahead_sz2);
     if (hsd == NULL) {
         fprintf(stderr, "Failed to alloc decoder\n");
@@ -679,38 +697,42 @@ prop_decoder_should_always_make_progress(struct theft *t, void *instance, void *
                 &r->buf[sunk], r->size - sunk, &input_size);
             if (sres < 0) {
                 fprintf(stderr, "Sink error %d\n", sres);
-                return THEFT_TRIAL_ERROR;
+                goto cleanup;
             }
             sunk += input_size;
         } else {
             HSD_finish_res fres = heatshrink_decoder_finish(hsd);
             if (fres == HSDR_FINISH_DONE) {
+                res = THEFT_TRIAL_PASS;
                 break;
             } else if (fres != HSDR_FINISH_MORE) {
                 printf("FAIL %d\n", __LINE__);
-                return THEFT_TRIAL_FAIL;
+                res = THEFT_TRIAL_FAIL;
+                goto cleanup;
             }
         }
 
         size_t output_size = 0;
         HSD_poll_res pres = heatshrink_decoder_poll(hsd,
-            output, sizeof(output), &output_size);
+            output, BUF_SIZE, &output_size);
         if (pres < 0) {
             fprintf(stderr, "poll error: %d\n", pres);
-            return THEFT_TRIAL_ERROR;
+            goto cleanup;
         }
         if (output_size == 0 && sunk == r->size) {
             no_progress++;
             if (no_progress > 2) {
-                return THEFT_TRIAL_FAIL;
+                res = THEFT_TRIAL_FAIL;
+                goto cleanup;
             }
         } else {
             no_progress = 0;
         }
     }
 
+cleanup:
     heatshrink_decoder_free(hsd);
-    return THEFT_TRIAL_PASS;
+    return res;
 }
 
 TEST decoder_should_always_make_progress(void) {

--- a/test_heatshrink_dynamic_theft.c
+++ b/test_heatshrink_dynamic_theft.c
@@ -36,13 +36,14 @@ typedef struct {
     uint8_t buf[];
 } rbuf;
 
-static void *rbuf_alloc_cb(struct theft *t, theft_hash seed, void *env) {
+static enum theft_alloc_res rbuf_alloc_cb(struct theft *t, void *env, void **output) {
     test_env *te = (test_env *)env;
+    theft_seed seed = theft_random(t);
     //printf("seed is 0x%016llx\n", seed);
 
     size_t sz = (size_t)(seed % te->limit) + 1;
     rbuf *r = malloc(sizeof(rbuf) + sz);
-    if (r == NULL) { return THEFT_ERROR; }
+    if (r == NULL) { return THEFT_ALLOC_ERROR; }
     r->size = sz;
 
     for (size_t i = 0; i < sz; i += sizeof(theft_hash)) {
@@ -53,7 +54,8 @@ static void *rbuf_alloc_cb(struct theft *t, theft_hash seed, void *env) {
         }
     }
 
-    return r;
+    *output = r;
+    return THEFT_ALLOC_OK;
 }
 
 static void rbuf_free_cb(void *instance, void *env) {
@@ -61,73 +63,78 @@ static void rbuf_free_cb(void *instance, void *env) {
     (void)env;
 }
 
-static uint64_t rbuf_hash_cb(void *instance, void *env) {
-    rbuf *r = (rbuf *)instance;
+static theft_hash rbuf_hash_cb(const void *instance, void *env) {
+    const rbuf *r = (const rbuf *)instance;
     (void)env;
     return theft_hash_onepass(r->buf, r->size);
 }
 
 /* Make a copy of a buffer, keeping NEW_SZ bytes starting at OFFSET. */
-static void *copy_rbuf_subset(rbuf *cur, size_t new_sz, size_t byte_offset) {
-    if (new_sz == 0) { return THEFT_DEAD_END; }
+static enum theft_shrink_res copy_rbuf_subset(const rbuf *cur, size_t new_sz,
+        size_t byte_offset, void **output) {
+    if (new_sz == 0) { return THEFT_SHRINK_DEAD_END; }
     rbuf *nr = malloc(sizeof(rbuf) + new_sz);
-    if (nr == NULL) { return THEFT_ERROR; }
+    if (nr == NULL) { return THEFT_SHRINK_ERROR; }
     nr->size = new_sz;
     memcpy(nr->buf, &cur->buf[byte_offset], new_sz);
     /* printf("%zu -> %zu\n", cur->size, new_sz); */
-    return nr;
+    *output = nr;
+    return THEFT_SHRINK_OK;
 }
 
 /* Make a copy of a buffer, but only PORTION, starting OFFSET in
  * (e.g. the third quarter is (0.25 at +0.75). Rounds to ints. */
-static void *copy_rbuf_percent(rbuf *cur, float portion, float offset) {
+static enum theft_shrink_res copy_rbuf_percent(const rbuf *cur, float portion,
+        float offset, void **output) {
     size_t new_sz = cur->size * portion;
     size_t byte_offset = (size_t)(cur->size * offset);
-    return copy_rbuf_subset(cur, new_sz, byte_offset);
+    return copy_rbuf_subset(cur, new_sz, byte_offset, output);
 }
 
 /* How to shrink a random buffer to a simpler one. */
-static void *rbuf_shrink_cb(void *instance, uint32_t tactic, void *env) {
-    rbuf *cur = (rbuf *)instance;
+static enum theft_shrink_res rbuf_shrink_cb(struct theft *t,
+        const void *instance, uint32_t tactic, void *env, void **output) {
+    const rbuf *cur = (const rbuf *)instance;
+    (void)t;
+    (void)env;
 
     if (tactic == 0) {          /* first half */
-        return copy_rbuf_percent(cur, 0.5, 0);
+        return copy_rbuf_percent(cur, 0.5, 0, output);
     } else if (tactic == 1) {   /* second half */
-        return copy_rbuf_percent(cur, 0.5, 0.5);
+        return copy_rbuf_percent(cur, 0.5, 0.5, output);
     } else if (tactic <= 18) {  /* drop 1-16 bytes at start */
         const int last_tactic = 1;
         const size_t drop = tactic - last_tactic;
-        if (cur->size < drop) { return THEFT_DEAD_END; }
-        return copy_rbuf_subset(cur, cur->size - drop, drop);
+        if (cur->size < drop) { return THEFT_SHRINK_DEAD_END; }
+        return copy_rbuf_subset(cur, cur->size - drop, drop, output);
     } else if (tactic <= 34) {  /* drop 1-16 bytes at end */
         const int last_tactic = 18;
         const size_t drop = tactic - last_tactic;
-        if (cur->size < drop) { return THEFT_DEAD_END; }
-        return copy_rbuf_subset(cur, cur->size - drop, 0);
-    } else if (tactic == 35) {
-        /* Divide every byte by 2, saturating at 0 */
-        rbuf *cp = copy_rbuf_percent(cur, 1, 0);
-        if (cp == NULL) { return THEFT_ERROR; }
-        for (size_t i = 0; i < cp->size; i++) { cp->buf[i] /= 2; }
-        return cp;
-    } else if (tactic == 36) {
-        /* subtract 1 from every byte, saturating at 0 */
-        rbuf *cp = copy_rbuf_percent(cur, 1, 0);
-        if (cp == NULL) { return THEFT_ERROR; }
-        for (size_t i = 0; i < cp->size; i++) {
-            if (cp->buf[i] > 0) { cp->buf[i]--; }
+        if (cur->size < drop) { return THEFT_SHRINK_DEAD_END; }
+        return copy_rbuf_subset(cur, cur->size - drop, 0, output);
+    } else if (tactic == 35 || tactic == 36) {
+        void *copy = NULL;
+        enum theft_shrink_res res = copy_rbuf_percent(cur, 1, 0, &copy);
+        if (res != THEFT_SHRINK_OK) { return res; }
+        rbuf *cp = (rbuf *)copy;
+        if (tactic == 35) {
+            /* Divide every byte by 2, saturating at 0 */
+            for (size_t i = 0; i < cp->size; i++) { cp->buf[i] /= 2; }
+        } else {
+            /* subtract 1 from every byte, saturating at 0 */
+            for (size_t i = 0; i < cp->size; i++) {
+                if (cp->buf[i] > 0) { cp->buf[i]--; }
+            }
         }
-        return cp;
+        *output = cp;
+        return THEFT_SHRINK_OK;
     } else {
-        (void)env;
-        return THEFT_NO_MORE_TACTICS;
+        return THEFT_SHRINK_NO_MORE_TACTICS;
     }
-
-    return THEFT_NO_MORE_TACTICS;
 }
 
-static void rbuf_print_cb(FILE *f, void *instance, void *env) {
-    rbuf *r = (rbuf *)instance;
+static void rbuf_print_cb(FILE *f, const void *instance, void *env) {
+    const rbuf *r = (const rbuf *)instance;
     (void)env;
     fprintf(f, "buf[%zd]:\n    ", r->size);
     uint8_t bytes = 0;
@@ -146,18 +153,20 @@ static struct theft_type_info rbuf_info = {
     .alloc = rbuf_alloc_cb,
     .free = rbuf_free_cb,
     .hash = rbuf_hash_cb,
-    .shrink = rbuf_shrink_cb,
     .print = rbuf_print_cb,
+    .shrink = rbuf_shrink_cb,
 };
 
-static void *window_alloc_cb(struct theft *t, theft_seed seed, void *env) {
+static enum theft_alloc_res window_alloc_cb(struct theft *t, void *env,
+        void **output) {
+    theft_seed seed = theft_random(t);
     uint8_t *window = malloc(sizeof(uint8_t));
-    if (window == NULL) { return THEFT_ERROR; }
+    if (window == NULL) { return THEFT_ALLOC_ERROR; }
     *window = (seed % (HEATSHRINK_MAX_WINDOW_BITS - HEATSHRINK_MIN_WINDOW_BITS))
       + HEATSHRINK_MIN_WINDOW_BITS;
-    (void)t;
     (void)env;
-    return window;
+    *output = window;
+    return THEFT_ALLOC_OK;
 }
 
 static void window_free_cb(void *instance, void *env) {
@@ -165,13 +174,13 @@ static void window_free_cb(void *instance, void *env) {
     (void)env;
 }
 
-static theft_hash window_hash_cb(void *instance, void *env) {
+static theft_hash window_hash_cb(const void *instance, void *env) {
     (void)env;
-    return *(uint8_t *)instance;
+    return *(const uint8_t *)instance;
 }
 
-static void window_print_cb(FILE *f, void *instance, void *env) {
-    fprintf(f, "%u", (*(uint8_t *)instance));
+static void window_print_cb(FILE *f, const void *instance, void *env) {
+    fprintf(f, "%u", (*(const uint8_t *)instance));
     (void)env;
 }
 
@@ -182,14 +191,16 @@ static struct theft_type_info window_info = {
     .print = window_print_cb,
 };
 
-static void *lookahead_alloc_cb(struct theft *t, theft_seed seed, void *env) {
+static enum theft_alloc_res lookahead_alloc_cb(struct theft *t, void *env,
+        void **output) {
+    theft_seed seed = theft_random(t);
     uint8_t *window = malloc(sizeof(uint8_t));
-    if (window == NULL) { return THEFT_ERROR; }
+    if (window == NULL) { return THEFT_ALLOC_ERROR; }
     *window = (seed % (HEATSHRINK_MAX_WINDOW_BITS - HEATSHRINK_MIN_LOOKAHEAD_BITS))
       + HEATSHRINK_MIN_LOOKAHEAD_BITS;
-    (void)t;
     (void)env;
-    return window;
+    *output = window;
+    return THEFT_ALLOC_OK;
 }
 
 static void lookahead_free_cb(void *instance, void *env) {
@@ -197,13 +208,13 @@ static void lookahead_free_cb(void *instance, void *env) {
     (void)env;
 }
 
-static theft_hash lookahead_hash_cb(void *instance, void *env) {
+static theft_hash lookahead_hash_cb(const void *instance, void *env) {
     (void)env;
-    return *(uint8_t *)instance;
+    return *(const uint8_t *)instance;
 }
 
-static void lookahead_print_cb(FILE *f, void *instance, void *env) {
-    fprintf(f, "%u", (*(uint8_t *)instance));
+static void lookahead_print_cb(FILE *f, const void *instance, void *env) {
+    fprintf(f, "%u", (*(const uint8_t *)instance));
     (void)env;
 }
 
@@ -215,9 +226,11 @@ static struct theft_type_info lookahead_info = {
 };
 
 
-static void *decoder_buf_alloc_cb(struct theft *t, theft_seed seed, void *env) {
+static enum theft_alloc_res decoder_buf_alloc_cb(struct theft *t, void *env,
+        void **output) {
+    theft_seed seed = theft_random(t);
     uint16_t *size = malloc(sizeof(uint16_t));
-    if (size == NULL) { return THEFT_ERROR; }
+    if (size == NULL) { return THEFT_ALLOC_ERROR; }
 
     /* Get a random uint16_t, and only keep bottom 0-15 bits at random,
      * to bias towards smaller buffers. */
@@ -225,9 +238,9 @@ static void *decoder_buf_alloc_cb(struct theft *t, theft_seed seed, void *env) {
     *size &= (1 << (theft_random(t) & 0xF)) - 1;
 
     if (*size == 0) { *size = 1; }   // round up to 1
-    (void)t;
     (void)env;
-    return size;
+    *output = size;
+    return THEFT_ALLOC_OK;
 }
 
 static void decoder_buf_free_cb(void *instance, void *env) {
@@ -235,13 +248,13 @@ static void decoder_buf_free_cb(void *instance, void *env) {
     (void)env;
 }
 
-static theft_hash decoder_buf_hash_cb(void *instance, void *env) {
+static theft_hash decoder_buf_hash_cb(const void *instance, void *env) {
     (void)env;
-    return *(uint16_t *)instance;
+    return *(const uint16_t *)instance;
 }
 
-static void decoder_buf_print_cb(FILE *f, void *instance, void *env) {
-    fprintf(f, "%u", (*(uint16_t *)instance));
+static void decoder_buf_print_cb(FILE *f, const void *instance, void *env) {
+    fprintf(f, "%u", (*(const uint16_t *)instance));
     (void)env;
 }
 
@@ -252,10 +265,19 @@ static struct theft_type_info decoder_buf_info = {
     .print = decoder_buf_print_cb,
 };
 
-static theft_progress_callback_res
-progress_cb(struct theft_trial_info *info, void *env) {
+static enum theft_hook_trial_pre_res
+progress_trial_pre_cb(const struct theft_hook_trial_pre_info *info, void *env) {
     test_env *te = (test_env *)env;
-    if ((info->trial & 0xff) == 0) {
+    (void)info;
+    return te->fails > 10
+        ? THEFT_HOOK_TRIAL_PRE_HALT
+        : THEFT_HOOK_TRIAL_PRE_CONTINUE;
+}
+
+static enum theft_hook_trial_post_res
+progress_trial_post_cb(const struct theft_hook_trial_post_info *info, void *env) {
+    test_env *te = (test_env *)env;
+    if ((info->trial_id & 0xff) == 0) {
         printf(".");
         fflush(stdout);
         te->dots++;
@@ -265,22 +287,20 @@ progress_cb(struct theft_trial_info *info, void *env) {
         }
     }
 
-    if (info->status == THEFT_TRIAL_FAIL) {
+    if (info->result == THEFT_TRIAL_FAIL) {
         te->fails++;
         rbuf *cur = info->args[0];
-        if (cur->size < 5) { return THEFT_PROGRESS_HALT; }
+        if (cur->size < 5) { te->fails = 11; }
     }
 
-    if (te->fails > 10) {
-        return THEFT_PROGRESS_HALT;
-    }
-    return THEFT_PROGRESS_CONTINUE;
+    return THEFT_HOOK_TRIAL_POST_CONTINUE;
 }
 
 /* For an arbitrary input buffer, it should never get stuck in a
  * state where the data has been sunk but no data can be polled. */
-static theft_trial_res
-prop_should_not_get_stuck(void *input, void *window, void *lookahead) {
+static enum theft_trial_res
+prop_should_not_get_stuck(struct theft *t, void *input, void *window, void *lookahead) {
+    (void)t;
     assert(window);
     uint8_t window_sz2 = *(uint8_t *)window;
     assert(lookahead);
@@ -324,25 +344,27 @@ TEST decoder_fuzzing_should_not_detect_stuck_state(void) {
     
     /* Pass the max buffer size for this property (4 KB) in a closure */
     test_env env = { .limit = 1 << 12 };
+    rbuf_info.env = &env;
 
     theft_seed always_seeds = { 0xe87bb1f61032a061 };
 
-    struct theft *t = theft_init(0);
-    struct theft_cfg cfg = {
+    struct theft_run_config cfg = {
         .name = __func__,
-        .fun = prop_should_not_get_stuck,
+        .prop3 = prop_should_not_get_stuck,
         .type_info = { &rbuf_info, &window_info, &lookahead_info },
         .seed = seed,
         .trials = 100000,
-        .progress_cb = progress_cb,
-        .env = &env,
+        .hooks = {
+            .trial_pre = progress_trial_pre_cb,
+            .trial_post = progress_trial_post_cb,
+            .env = &env,
+        },
 
         .always_seeds = &always_seeds,
         .always_seed_count = 1,
     };
 
-    theft_run_res res = theft_run(t, &cfg);
-    theft_free(t);
+    enum theft_run_res res = theft_run(&cfg);
     printf("\n");
     GREATEST_ASSERT_EQm("should_not_get_stuck", THEFT_RUN_PASS, res);
     PASS();
@@ -421,9 +443,10 @@ static bool do_decompress(heatshrink_decoder *hsd,
     return dfres == HSDR_FINISH_DONE;
 }
 
-static theft_trial_res
-prop_encoded_and_decoded_data_should_match(void *input,
+static enum theft_trial_res
+prop_encoded_and_decoded_data_should_match(struct theft *t, void *input,
         void *window, void *lookahead, void *decoder_buffer_size) {
+    (void)t;
     assert(window);
     uint8_t window_sz2 = *(uint8_t *)window;
     assert(lookahead);
@@ -467,23 +490,25 @@ prop_encoded_and_decoded_data_should_match(void *input,
 
 TEST encoded_and_decoded_data_should_match(void) {
     test_env env = { .limit = 1 << 11 };
+    rbuf_info.env = &env;
     
     theft_seed seed;
     if (!get_time_seed(&seed)) { FAIL(); }
 
-    struct theft *t = theft_init(0);
-    struct theft_cfg cfg = {
+    struct theft_run_config cfg = {
         .name = __func__,
-        .fun = prop_encoded_and_decoded_data_should_match,
+        .prop4 = prop_encoded_and_decoded_data_should_match,
         .type_info = { &rbuf_info, &window_info, &lookahead_info, &decoder_buf_info, },
         .seed = seed,
         .trials = 1000000,
-        .env = &env,
-        .progress_cb = progress_cb,
+        .hooks = {
+            .trial_pre = progress_trial_pre_cb,
+            .trial_post = progress_trial_post_cb,
+            .env = &env,
+        },
     };
 
-    theft_run_res res = theft_run(t, &cfg);
-    theft_free(t);
+    enum theft_run_res res = theft_run(&cfg);
     printf("\n");
     ASSERT_EQ(THEFT_RUN_PASS, res);
     PASS();
@@ -493,9 +518,10 @@ static size_t ceil_nine_eighths(size_t sz) {
     return sz + sz/8 + (sz & 0x07 ? 1 : 0);
 }
 
-static theft_trial_res
-prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(void *input,
+static enum theft_trial_res
+prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(struct theft *t, void *input,
         void *window, void *lookahead) {
+    (void)t;
     assert(window);
     uint8_t window_sz2 = *(uint8_t *)window;
     assert(lookahead);
@@ -524,30 +550,33 @@ prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(void
 
 TEST encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst(void) {
     test_env env = { .limit = 1 << 11 };
+    rbuf_info.env = &env;
     
     theft_seed seed;
     if (!get_time_seed(&seed)) { FAIL(); }
 
-    struct theft *t = theft_init(0);
-    struct theft_cfg cfg = {
+    struct theft_run_config cfg = {
         .name = __func__,
-        .fun = prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst,
+        .prop3 = prop_encoding_data_should_never_increase_it_by_more_than_an_eighth_at_worst,
         .type_info = { &rbuf_info, &window_info, &lookahead_info },
         .seed = seed,
         .trials = 10000,
-        .env = &env,
-        .progress_cb = progress_cb,
+        .hooks = {
+            .trial_pre = progress_trial_pre_cb,
+            .trial_post = progress_trial_post_cb,
+            .env = &env,
+        },
     };
 
-    theft_run_res res = theft_run(t, &cfg);
-    theft_free(t);
+    enum theft_run_res res = theft_run(&cfg);
     printf("\n");
     ASSERT_EQ(THEFT_RUN_PASS, res);
     PASS();
 }
 
-static theft_trial_res
-prop_encoder_should_always_make_progress(void *instance, void *window, void *lookahead) {
+static enum theft_trial_res
+prop_encoder_should_always_make_progress(struct theft *t, void *instance, void *window, void *lookahead) {
+    (void)t;
     assert(window);
     uint8_t window_sz2 = *(uint8_t *)window;
     assert(lookahead);
@@ -599,30 +628,33 @@ prop_encoder_should_always_make_progress(void *instance, void *window, void *loo
 
 TEST encoder_should_always_make_progress(void) {
     test_env env = { .limit = 1 << 15 };
+    rbuf_info.env = &env;
     
     theft_seed seed;
     if (!get_time_seed(&seed)) { FAIL(); }
 
-    struct theft *t = theft_init(0);
-    struct theft_cfg cfg = {
+    struct theft_run_config cfg = {
         .name = __func__,
-        .fun = prop_encoder_should_always_make_progress,
+        .prop3 = prop_encoder_should_always_make_progress,
         .type_info = { &rbuf_info, &window_info, &lookahead_info },
         .seed = seed,
         .trials = 10000,
-        .env = &env,
-        .progress_cb = progress_cb,
+        .hooks = {
+            .trial_pre = progress_trial_pre_cb,
+            .trial_post = progress_trial_post_cb,
+            .env = &env,
+        },
     };
 
-    theft_run_res res = theft_run(t, &cfg);
-    theft_free(t);
+    enum theft_run_res res = theft_run(&cfg);
     printf("\n");
     ASSERT_EQ(THEFT_RUN_PASS, res);
     PASS();
 }
 
-static theft_trial_res
-prop_decoder_should_always_make_progress(void *instance, void *window, void *lookahead) {
+static enum theft_trial_res
+prop_decoder_should_always_make_progress(struct theft *t, void *instance, void *window, void *lookahead) {
+    (void)t;
     assert(window);
     uint8_t window_sz2 = *(uint8_t *)window;
     assert(lookahead);
@@ -683,23 +715,25 @@ prop_decoder_should_always_make_progress(void *instance, void *window, void *loo
 
 TEST decoder_should_always_make_progress(void) {
     test_env env = { .limit = 1 << 15 };
+    rbuf_info.env = &env;
     
     theft_seed seed;
     if (!get_time_seed(&seed)) { FAIL(); }
 
-    struct theft *t = theft_init(0);
-    struct theft_cfg cfg = {
+    struct theft_run_config cfg = {
         .name = __func__,
-        .fun = prop_decoder_should_always_make_progress,
+        .prop3 = prop_decoder_should_always_make_progress,
         .type_info = { &rbuf_info, &window_info, &lookahead_info },
         .seed = seed,
         .trials = 10000,
-        .env = &env,
-        .progress_cb = progress_cb,
+        .hooks = {
+            .trial_pre = progress_trial_pre_cb,
+            .trial_post = progress_trial_post_cb,
+            .env = &env,
+        },
     };
 
-    theft_run_res res = theft_run(t, &cfg);
-    theft_free(t);
+    enum theft_run_res res = theft_run(&cfg);
     printf("\n");
     ASSERT_EQ(THEFT_RUN_PASS, res);
     PASS();


### PR DESCRIPTION
### Motivation
- The property tests used an older libtheft API: alloc/shrink callbacks returned pointers/values and used deprecated constants, and the test harness used the older `theft_cfg`/progress callback API causing compilation failures with current libtheft headers.

### Description
- Converted alloc callbacks to return `enum theft_alloc_res` and accept an `void **output` parameter and replaced `THEFT_ERROR` with `THEFT_ALLOC_ERROR` and successful return with `THEFT_ALLOC_OK` (e.g. `rbuf_alloc_cb`, `window_alloc_cb`, `lookahead_alloc_cb`, `decoder_buf_alloc_cb`).
- Converted shrink helpers and callbacks to return `enum theft_shrink_res` and return new constants like `THEFT_SHRINK_OK`, `THEFT_SHRINK_DEAD_END`, `THEFT_SHRINK_ERROR`, and `THEFT_SHRINK_NO_MORE_TACTICS`, and to populate results via `void **output` (e.g. `copy_rbuf_subset`, `copy_rbuf_percent`, `rbuf_shrink_cb`).
- Updated hash/print callback signatures to accept `const void *` (e.g. `rbuf_hash_cb`, `window_hash_cb`, `lookahead_hash_cb`, `decoder_buf_hash_cb`, and corresponding `*_print_cb`).
- Replaced the old progress callback with hook-based trial hooks and migrated test configuration to `struct theft_run_config` using `.prop3`/`.prop4`, `.hooks`, and `theft_run(&cfg)`; also wired `rbuf_info.env` to pass `test_env` into generators.
- All changes are contained in the test file `test_heatshrink_dynamic_theft.c` to adapt the tests to the current libtheft API.

### Testing
- Performed a syntax-only compile against a local mock of the current theft header with `cc -fsyntax-only -DHEATSHRINK_HAS_THEFT -DHEATSHRINK_DYNAMIC_ALLOC=1 -I/tmp/theft-current -std=c99 ... test_heatshrink_dynamic_theft.c`, which succeeded. 
- Ran the full test suite with `make test`, and all tests passed (12282 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a049bf2c7908331a37ab5f5772e5ef0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite migrated to an updated dynamic-allocation fuzzing framework.
  * Property checks (roundtrip, progress guarantees, bounded growth) preserved and adapted to new trial lifecycle.
  * Progress reporting and failure counting refactored to per-trial hooks.
  * Test execution switched to a consolidated run/config approach for per-test configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miracoli/heatshrink/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->