### PR TITLE
Fix boundary checks in st_step_search to handle finishing and lookahead correctly

### DIFF
--- a/heatshrink_encoder.c
+++ b/heatshrink_encoder.c
@@ -265,11 +265,10 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
         msi, hse->input_size + msi, 2*window_length, hse->input_size);
 
     bool fin = is_finishing(hse);
-    if (fin && hse->input_size == 0) {
-        return HSES_FLUSH_BITS;
-    } else if (msi > hse->input_size - (fin ? 1 : lookahead_sz)) {
-        /* Current search buffer is exhausted, copy it into the
-         * backlog and await more input. */
+    uint16_t input_needed = msi + (fin ? 1 : lookahead_sz);
+    if (input_needed > hse->input_size) {
+        /* Current search buffer is exhausted. If finishing, no input remains
+         * to scan; otherwise, copy it into the backlog and await more input. */
         LOG("-- end of search @ %d\n", msi);
         return fin ? HSES_FLUSH_BITS : HSES_SAVE_BACKLOG;
     }
@@ -278,11 +277,9 @@ static HSE_state st_step_search(heatshrink_encoder *hse) {
     uint16_t end = input_offset + msi;
     uint16_t start = end - window_length;
 
-    uint16_t max_possible = lookahead_sz;
-    if (hse->input_size - msi < lookahead_sz) {
-        max_possible = hse->input_size - msi;
-    }
-    
+    uint16_t remaining = hse->input_size - msi;
+    uint16_t max_possible = remaining < lookahead_sz ? remaining : lookahead_sz;
+
     uint16_t match_length = 0;
     uint16_t match_pos = find_longest_match(hse,
         start, end, max_possible, &match_length);


### PR DESCRIPTION
### Motivation
- Correct ambiguous and error-prone boundary logic in `st_step_search` so the encoder handles end-of-input and lookahead limits deterministically and without off-by-one mistakes.

### Description
- Replace the previous conditional with an explicit `input_needed = msi + (fin ? 1 : lookahead_sz)` and use `input_needed > hse->input_size` to choose between `HSES_FLUSH_BITS` and `HSES_SAVE_BACKLOG`.
- Compute `remaining = hse->input_size - msi` and set `max_possible = remaining < lookahead_sz ? remaining : lookahead_sz` to simplify and clarify the maximum match length calculation.

### Testing
- Compiled the project and ran the encoder unit test suite including compression/decompression roundtrip tests, and all tests passed.
- Exercised end-of-input boundary cases with a set of sample inputs to validate lookahead and finishing behavior, which produced expected outputs with no crashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a049e54c41883319347075fa39ef908)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the encoder's logic for determining search window exhaustion, improving efficiency in data processing and flushing decisions.
  * Streamlined the calculation of lookahead limits during match finding for better overall performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miracoli/heatshrink/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->